### PR TITLE
341 backport grafana dashboards and datasources to kube prometheus stack chart

### DIFF
--- a/clusters/k8s-01/apps/monitoring/kube-prometheus-stack/app.yaml
+++ b/clusters/k8s-01/apps/monitoring/kube-prometheus-stack/app.yaml
@@ -91,8 +91,20 @@ spec:
                 url: http://loki-headless.monitoring.svc.cluster.local:3100
                 jsonData:
                   maxLines: 250
+          dashboardProviders:
+            dashboardproviders.yaml:
+              apiVersion: 1
+              providers:
+                - name: default
+                  orgId: 1
+                  folder: ""
+                  type: file
+                  disableDeletion: false
+                  editable: false
+                  options:
+                    path: /var/lib/grafana/dashboards/default
           dashboards:
-            sidecarProvider:
+            default:
               unifi-insights:
                 gnetId: 11315
                 revision: 9


### PR DESCRIPTION
- **feat(grafana): try to import dashboards from helm**
- **fix(grafana): add default dashboardprovider**
