### PR TITLE
feat(security): add OpenBao ArgoCD app (RAFT + static seal)

### DIFF
--- a/clusters/k8s-01/apps/kustomization.yaml
+++ b/clusters/k8s-01/apps/kustomization.yaml
@@ -29,3 +29,4 @@ resources:
   - mail
   - buildkite
   - matrix
+  - security

--- a/clusters/k8s-01/apps/security/kustomization.yaml
+++ b/clusters/k8s-01/apps/security/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - openbao

--- a/clusters/k8s-01/apps/security/openbao/app.yaml
+++ b/clusters/k8s-01/apps/security/openbao/app.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openbao
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - chart: openbao
+      repoURL: https://openbao.github.io/openbao-helm
+      targetRevision: 0.4.0
+      helm:
+        valuesObject:
+          global:
+            enabled: true
+          injector:
+            enabled: false
+          csi:
+            enabled: false
+          ui:
+            enabled: true
+            serviceType: ClusterIP
+          server:
+            ingress:
+              enabled: false
+            standalone:
+              enabled: false
+            serviceAccount:
+              create: true
+              serviceDiscovery:
+                enabled: true
+            dataStorage:
+              enabled: true
+              size: 10Gi
+              mountPath: /openbao/data
+              storageClass: ceph-block
+              accessMode: ReadWriteOnce
+            auditStorage:
+              enabled: false
+            extraSecretEnvironmentVars:
+              - envName: BAO_SEAL_UNSEAL_KEY
+                secretName: openbao-unseal
+                secretKey: key
+            ha:
+              enabled: true
+              replicas: 3
+              raft:
+                enabled: true
+                setNodeId: true
+                config: |
+                  ui = true
+
+                  listener "tcp" {
+                    tls_disable     = 1
+                    address         = "[::]:8200"
+                    cluster_address = "[::]:8201"
+                    telemetry {
+                      unauthenticated_metrics_access = "true"
+                    }
+                  }
+
+                  storage "raft" {
+                    path = "/openbao/data"
+
+                    retry_join {
+                      leader_api_addr = "http://openbao-0.openbao-internal:8200"
+                    }
+                    retry_join {
+                      leader_api_addr = "http://openbao-1.openbao-internal:8200"
+                    }
+                    retry_join {
+                      leader_api_addr = "http://openbao-2.openbao-internal:8200"
+                    }
+                  }
+
+                  seal "static" {
+                    current_key_id = "homelab-v1"
+                    current_key    = "env://BAO_SEAL_UNSEAL_KEY"
+                  }
+
+                  telemetry {
+                    prometheus_retention_time = "30s"
+                    disable_hostname          = true
+                  }
+
+                  service_registration "kubernetes" {}
+    - path: clusters/k8s-01/apps/security/openbao/configs
+      repoURL: 'https://github.com/synthe102/homelab.git'
+      targetRevision: HEAD
+  destination:
+    name: in-cluster
+    namespace: openbao
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/clusters/k8s-01/apps/security/openbao/configs/externalSecret.yaml
+++ b/clusters/k8s-01/apps/security/openbao/configs/externalSecret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openbao-unseal
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: bitwarden-homelab
+    kind: ClusterSecretStore
+  data:
+    - secretKey: key
+      remoteRef:
+        key: "K8S_01_KUBE_OPENBAO_UNSEAL_KEY"

--- a/clusters/k8s-01/apps/security/openbao/configs/httproute.yaml
+++ b/clusters/k8s-01/apps/security/openbao/configs/httproute.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: openbao
+spec:
+  hostnames:
+    - openbao.k8s-01.suslian.engineer
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: internal
+      namespace: kube-system
+      sectionName: https-k8s-01
+  rules:
+    - backendRefs:
+        - group: ''
+          kind: Service
+          name: openbao-active
+          port: 8200
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/clusters/k8s-01/apps/security/openbao/configs/kustomization.yaml
+++ b/clusters/k8s-01/apps/security/openbao/configs/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - externalSecret.yaml
+  - httproute.yaml

--- a/clusters/k8s-01/apps/security/openbao/kustomization.yaml
+++ b/clusters/k8s-01/apps/security/openbao/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app.yaml


### PR DESCRIPTION
## Summary

- Adds a new `security/` category with OpenBao deployed via the upstream Helm chart (`openbao/openbao` @ `0.4.0`) in HA + integrated-storage (RAFT) mode, 3 replicas, `ceph-block` persistence.
- Wires **static-key auto-unseal** (https://openbao.org/docs/configuration/seal/static/): a 32-byte hex key lives in BitWarden as `K8S_01_KUBE_OPENBAO_UNSEAL_KEY`, gets synced into the `openbao` namespace by an `ExternalSecret`, and is injected into each pod as `BAO_SEAL_UNSEAL_KEY` which the `seal "static"` stanza references via `env://`. Pods self-unseal on every restart — no manual `bao operator unseal`.
- `retry_join` blocks in the raft HCL point at all three pod FQDNs, so peers self-form the cluster without manual `bao operator raft join`.
- `HTTPRoute` at `openbao.k8s-01.suslian.engineer` → `openbao-active:8200`.
- Agent Injector and CSI subcharts disabled; audit storage disabled for now.

## Post-merge (one-time, manual)

Once ArgoCD has synced and the 3 pods are `Running` but sealed/uninitialized:

```
kubectl -n openbao exec openbao-0 -- bao operator init \
  -recovery-shares=5 -recovery-threshold=3 -format=json
```

Store the output back into BitWarden as `K8S_01_KUBE_OPENBAO_RECOVERY_KEYS` and `K8S_01_KUBE_OPENBAO_ROOT_TOKEN`. After that, peers auto-join and auto-unseal.

## Test plan

- [ ] `argocd-diff` workflow comment shows the expected resources (Application, Namespace, StatefulSet with 3 replicas, 4 Services, 3 PVCs on `ceph-block`, ExternalSecret, HTTPRoute) and no Injector/CSI resources
- [ ] After merge: `kubectl -n argocd get app openbao` → `Synced`
- [ ] `kubectl -n openbao get secret openbao-unseal` exists with key `key`
- [ ] Run `bao operator init` on `openbao-0` with `-recovery-shares=5 -recovery-threshold=3`; store recovery keys + root token back into BitWarden
- [ ] `bao operator raft list-peers` shows 3 peers within ~30s
- [ ] `curl -k https://openbao.k8s-01.suslian.engineer/v1/sys/health` returns 200/429/501
- [ ] **Auto-unseal check**: `kubectl -n openbao delete pod openbao-0` — replacement pod returns `1/1 Ready` on its own (no manual unseal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)