### PR TITLE
feat(minecraft): drop FifthColumnMC griefer IPs at the network policy

### DIFF
--- a/clusters/k8s-01/apps/game-servers/minecraft/configs/netpol.yaml
+++ b/clusters/k8s-01/apps/game-servers/minecraft/configs/netpol.yaml
@@ -8,6 +8,19 @@ spec:
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: minecraft-volcan
+  # Drop known FifthColumnMC griefer/scanner source IPs at L3, before traffic
+  # ever reaches the JVM. This is a deny-only ingress rule: enableDefaultDeny.ingress
+  # is set to false so the endpoint stays open to everyone else (legit players, the
+  # LoadBalancer, metrics scraping). Without that, a lone ingressDeny rule would flip
+  # the endpoint into ingress default-deny and lock the whole server out.
+  enableDefaultDeny:
+    ingress: false
+    egress: true
+  ingressDeny:
+    - fromCIDR:
+        - 213.152.161.54/32 # FifthColumnMC - main campaign (~1167 attempts)
+        - 176.65.148.154/32 # FifthColumnMC - secondary (~372 attempts)
+        - 204.76.203.35/32 # FifthColumnMC - original prober/recon (Feb 2026)
   egressDeny:
     - toCIDR:
         - 192.168.0.0/16


### PR DESCRIPTION
## What

Adds a **deny-only ingress rule** to the `minecraft-volcan` CiliumNetworkPolicy, dropping the three source IPs used by the `FifthColumnMC` connection-spam bot at L3 — before traffic reaches the Paper JVM.

| IP | Attempts logged | First seen |
|---|---|---|
| `213.152.161.54` | ~1,167 (current campaign) | 2026-03-03 |
| `176.65.148.154` | ~372 | 2026-02-15 |
| `204.76.203.35` | ~6 (recon/prober) | 2026-02-12 |

## Why

`FifthColumnMC` has hammered the server with ~1,500 connection attempts since **2026-02-14**. They **never got in** — `online-mode=true` + `white-list=true`/`enforce-whitelist=true` blocked every attempt at the login phase (no `joined the game` line exists for them in any of 121 log files). This isn't a breach fix; it sheds the constant connection load and log noise.

These IPs are already banned in-game via `ban-ip` (persisted to `banned-ips.json` on the PVC), but that only rejects them *after* the TCP/handshake reaches the JVM. This policy drops the packets earlier and puts the block under GitOps.

## Safety — why this won't lock out players

A lone `ingressDeny` rule would flip the endpoint into **ingress default-deny** and block *everyone*. To prevent that, `enableDefaultDeny.ingress: false` keeps ingress open to all other sources (legit players, the LoadBalancer, Prometheus metrics scraping); only the listed CIDRs are denied. `egress` behaviour is unchanged (`enableDefaultDeny.egress: true` preserves the existing world + kube-dns allow-list and the `192.168.0.0/16` deny).

## Validation

- `kubectl apply --dry-run=server` against the live Cilium **v1.19.4** CRD → accepted (`configured`).
- `yamlfmt` clean (pre-commit passed).
- ArgoCD diff preview will render the rule on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)