### PR TITLE
feat(monitoring): manage Mimir Kafka with Strimzi

### DIFF
--- a/clusters/k8s-01/apps/kustomization.yaml
+++ b/clusters/k8s-01/apps/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - monitoring
   - rook
   - cnpg
+  - strimzi
   - external-dns
   - external-secrets
   - cert-manager

--- a/clusters/k8s-01/apps/monitoring/k8s-monitoring/app.yaml
+++ b/clusters/k8s-01/apps/monitoring/k8s-monitoring/app.yaml
@@ -26,6 +26,26 @@ spec:
                 address = "http://mimir-ruler.monitoring.svc:8080"
                 tenant_id = "anonymous"
               }
+
+              mimir.alerts.kubernetes "default" {
+                address = "http://mimir-gateway.monitoring.svc.cluster.local:80"
+                global_config = `
+              route:
+                receiver: "null"
+              receivers:
+                - name: "null"
+              `
+
+                alertmanagerconfig_selector {
+                  match_labels = {
+                    "alertmanager" = "mimir",
+                  }
+                }
+
+                alertmanagerconfig_matcher {
+                  strategy = "None"
+                }
+              }
           alloy-logs:
             presets: [filesystem-log-reader, daemonset]
           alloy-metrics:

--- a/clusters/k8s-01/apps/monitoring/kube-prometheus-stack/configs/alertmanagerconfig.yaml
+++ b/clusters/k8s-01/apps/monitoring/kube-prometheus-stack/configs/alertmanagerconfig.yaml
@@ -4,6 +4,8 @@ apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:
   name: alertmanager
+  labels:
+    alertmanager: mimir
 spec:
   route:
     groupBy: ["alertname", "job"]
@@ -18,11 +20,11 @@ spec:
             value: critical
             matchType: =
   receivers:
-  - name: "null"
-  - name: telegram
-    telegramConfigs:
-      - botToken:
-          name: telegram-bot-token
-          key: bot-token
-        chatID: -4797781084
-        sendResolved: true
+    - name: "null"
+    - name: telegram
+      telegramConfigs:
+        - botToken:
+            name: telegram-bot-token
+            key: bot-token
+          chatID: -4797781084
+          sendResolved: true

--- a/clusters/k8s-01/apps/monitoring/kustomization.yaml
+++ b/clusters/k8s-01/apps/monitoring/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - kube-prometheus-stack
   - loki
   - mimir
+  - mimir-kafka
   - unpoller
   - smartctl-exporter
   - k8s-monitoring

--- a/clusters/k8s-01/apps/monitoring/mimir-kafka/app.yaml
+++ b/clusters/k8s-01/apps/monitoring/mimir-kafka/app.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mimir-kafka
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    path: clusters/k8s-01/apps/monitoring/mimir-kafka/configs
+    repoURL: https://github.com/synthe102/homelab.git
+    targetRevision: HEAD
+  destination:
+    name: in-cluster
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/clusters/k8s-01/apps/monitoring/mimir-kafka/configs/kafka.yaml
+++ b/clusters/k8s-01/apps/monitoring/mimir-kafka/configs/kafka.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mimir-kafka-metrics
+data:
+  kafka-metrics-config.yml: |
+    lowercaseOutputName: true
+    rules:
+      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Value
+        name: kafka_$1_$2_$3
+        type: GAUGE
+        labels:
+          "$4": "$5"
+          "$6": "$7"
+      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Value
+        name: kafka_$1_$2_$3
+        type: GAUGE
+        labels:
+          "$4": "$5"
+      - pattern: kafka.(\w+)<type=(.+), name=(.+)><>Value
+        name: kafka_$1_$2_$3
+        type: GAUGE
+      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Count
+        name: kafka_$1_$2_$3_total
+        type: COUNTER
+        labels:
+          "$4": "$5"
+      - pattern: kafka.(\w+)<type=(.+), name=(.+)><>Count
+        name: kafka_$1_$2_$3_total
+        type: COUNTER
+      - pattern: "kafka.server<type=raft-metrics><>(.+):"
+        name: kafka_server_raftmetrics_$1
+        type: GAUGE
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: mixed
+  labels:
+    strimzi.io/cluster: mimir
+spec:
+  replicas: 3
+  roles:
+    - broker
+    - controller
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  jvmOptions:
+    -Xms: 768m
+    -Xmx: 768m
+    gcLoggingEnabled: false
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 20Gi
+        class: ceph-block-xfs
+        deleteClaim: false
+        kraftMetadata: shared
+  template:
+    pod:
+      terminationGracePeriodSeconds: 60
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  strimzi.io/name: mimir-kafka
+              topologyKey: kubernetes.io/hostname
+---
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: mimir
+spec:
+  kafka:
+    version: 4.2.1
+    metadataVersion: 4.2-IV1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+    config:
+      auto.create.topics.enable: false
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      log.cleanup.policy: delete
+      log.retention.hours: 24
+      log.retention.check.interval.ms: 300000
+      log.segment.bytes: 268435456
+      log.segment.ms: 3600000
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: mimir-kafka-metrics
+          key: kafka-metrics-config.yml
+  entityOperator:
+    topicOperator:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+  kafkaExporter:
+    topicRegex: mimir-.*
+    groupRegex: mimir-.*
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: mimir-ingest
+  labels:
+    strimzi.io/cluster: mimir
+spec:
+  topicName: mimir-ingest
+  partitions: 12
+  replicas: 3
+  config:
+    cleanup.policy: delete
+    min.insync.replicas: 2
+    retention.ms: 86400000
+    segment.ms: 3600000

--- a/clusters/k8s-01/apps/monitoring/mimir-kafka/configs/kustomization.yaml
+++ b/clusters/k8s-01/apps/monitoring/mimir-kafka/configs/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kafka.yaml
+  - monitoring.yaml

--- a/clusters/k8s-01/apps/monitoring/mimir-kafka/configs/monitoring.yaml
+++ b/clusters/k8s-01/apps/monitoring/mimir-kafka/configs/monitoring.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: mimir-kafka
+spec:
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  selector:
+    matchLabels:
+      strimzi.io/cluster: mimir
+  podMetricsEndpoints:
+    - path: /metrics
+      port: tcp-prometheus
+      relabelings:
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(strimzi_io_.+)
+        - action: replace
+          sourceLabels:
+            - __meta_kubernetes_namespace
+          targetLabel: namespace
+        - action: replace
+          sourceLabels:
+            - __meta_kubernetes_pod_name
+          targetLabel: kubernetes_pod_name
+        - action: replace
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node_name
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mimir-kafka
+spec:
+  groups:
+    - name: mimir-kafka
+      rules:
+        - alert: MimirKafkaDiskSpaceLow
+          expr: |
+            (
+              kubelet_volume_stats_available_bytes{
+                namespace="monitoring",
+                persistentvolumeclaim=~"data-0-mimir-mixed-[0-9]+"
+              }
+              /
+              kubelet_volume_stats_capacity_bytes{
+                namespace="monitoring",
+                persistentvolumeclaim=~"data-0-mimir-mixed-[0-9]+"
+              }
+            ) < 0.20
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: Mimir Kafka is running low on disk space
+            description: >-
+              Kafka PVC {{ $labels.persistentvolumeclaim }} has less than 20% free space remaining.
+        - alert: MimirKafkaDiskSpaceCritical
+          expr: |
+            (
+              kubelet_volume_stats_available_bytes{
+                namespace="monitoring",
+                persistentvolumeclaim=~"data-0-mimir-mixed-[0-9]+"
+              }
+              /
+              kubelet_volume_stats_capacity_bytes{
+                namespace="monitoring",
+                persistentvolumeclaim=~"data-0-mimir-mixed-[0-9]+"
+              }
+            ) < 0.10
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Mimir Kafka is critically low on disk space
+            description: >-
+              Kafka PVC {{ $labels.persistentvolumeclaim }} has less than 10% free space remaining.
+        - alert: MimirKafkaBrokerNotReady
+          expr: |
+            kube_pod_status_ready{
+              namespace="monitoring",
+              pod=~"mimir-mixed-[0-9]+",
+              condition="true"
+            } == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: A Mimir Kafka broker is not ready
+            description: Kafka broker {{ $labels.pod }} has not been ready for five minutes.
+        - alert: MimirKafkaUnderReplicatedPartitions
+          expr: kafka_server_replicamanager_underreplicatedpartitions > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Mimir Kafka has under-replicated partitions
+            description: >-
+              Broker {{ $labels.kubernetes_pod_name }} has {{ $value }} under-replicated partitions.
+        - alert: MimirKafkaUnderMinISRPartitions
+          expr: kafka_server_replicamanager_underminisrpartitioncount > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Mimir Kafka has partitions below minimum ISR
+            description: >-
+              Broker {{ $labels.kubernetes_pod_name }} has {{ $value }} partitions below minimum ISR.
+        - alert: MimirKafkaOfflineLogDirectory
+          expr: kafka_log_logmanager_offlinelogdirectorycount > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Mimir Kafka has an offline log directory
+            description: >-
+              Broker {{ $labels.kubernetes_pod_name }} reports an offline Kafka log directory.

--- a/clusters/k8s-01/apps/monitoring/mimir-kafka/kustomization.yaml
+++ b/clusters/k8s-01/apps/monitoring/mimir-kafka/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app.yaml

--- a/clusters/k8s-01/apps/monitoring/mimir/app.yaml
+++ b/clusters/k8s-01/apps/monitoring/mimir/app.yaml
@@ -4,6 +4,8 @@ kind: Application
 metadata:
   name: mimir
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -57,11 +59,16 @@ spec:
           distributor:
             replicas: 2
           kafka:
-            extraEnv:
-              - name: KAFKA_LOG_RETENTION_BYTES
-                value: "2000000000"
+            enabled: false
           mimir:
             structuredConfig:
+              ingest_storage:
+                enabled: true
+                kafka:
+                  address: mimir-kafka-bootstrap.monitoring.svc.cluster.local:9092
+                  auto_create_topic_enabled: false
+                  auto_create_topic_default_partitions: 12
+                  topic: mimir-ingest
               common:
                 storage:
                   backend: s3

--- a/clusters/k8s-01/apps/strimzi/app.yaml
+++ b/clusters/k8s-01/apps/strimzi/app.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: strimzi
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    chart: strimzi-kafka-operator
+    repoURL: https://strimzi.io/charts
+    targetRevision: 1.1.0
+    helm:
+      releaseName: strimzi-cluster-operator
+      valuesObject:
+        watchNamespaces:
+          - monitoring
+        dashboards:
+          enabled: true
+          namespace: monitoring
+          annotations:
+            k8s-sidecar-target-directory: /tmp/dashboards/Kafka
+        podDisruptionBudget:
+          enabled: true
+          minAvailable: 1
+  destination:
+    name: in-cluster
+    namespace: strimzi-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/clusters/k8s-01/apps/strimzi/kustomization.yaml
+++ b/clusters/k8s-01/apps/strimzi/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app.yaml


### PR DESCRIPTION
## Summary
- sync AlertmanagerConfig resources into Mimir
- deploy Strimzi 1.1.0 and a three-node KRaft Kafka cluster for Mimir
- use replicated Ceph/XFS storage with RF=3 and min ISR=2
- switch Mimir away from the demo Kafka bundled in its chart
- add Kafka metrics discovery and capacity/replication alerts

## Validation
- rendered the full app-of-apps Kustomize tree
- server-side dry-run of Strimzi custom resources
- three brokers scheduled across three nodes
- replicated Kafka produce/consume smoke test
- Mimir topic has 12 partitions, RF=3, and all replicas in sync