### PR TITLE
fix(monitoring): reduce Mimir Kafka retention to 12h

### DIFF
--- a/clusters/k8s-01/apps/monitoring/mimir-kafka/configs/kafka.yaml
+++ b/clusters/k8s-01/apps/monitoring/mimir-kafka/configs/kafka.yaml
@@ -96,7 +96,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.cleanup.policy: delete
-      log.retention.hours: 24
+      log.retention.hours: 12
       log.retention.check.interval.ms: 300000
       log.segment.bytes: 268435456
       log.segment.ms: 3600000
@@ -139,5 +139,5 @@ spec:
   config:
     cleanup.policy: delete
     min.insync.replicas: 2
-    retention.ms: 86400000
+    retention.ms: 43200000
     segment.ms: 3600000


### PR DESCRIPTION
## Summary
- reduce the Mimir Kafka broker default retention from 24 hours to 12 hours
- reduce the managed `mimir-ingest` topic retention from 24 hours to 12 hours

The topic currently consumes about 47 GiB across three replicas (roughly 15.7 GiB per 20 GiB broker). Twelve-hour retention should approximately halve the steady-state disk footprint.

## Validation
- full app-of-apps Kustomize tree renders successfully
- Kafka and KafkaTopic resources are currently healthy
- one-hour segments and five-minute retention checks remain configured for timely cleanup